### PR TITLE
Passphrase Card component

### DIFF
--- a/src/lib/components/Passphrase-Card.stories.svelte
+++ b/src/lib/components/Passphrase-Card.stories.svelte
@@ -1,0 +1,19 @@
+<script module>
+    import { defineMeta } from "@storybook/addon-svelte-csf";
+    import Button from "./Passphrase-Card.svelte";
+    import { fn } from "@storybook/test";
+
+    const demoPassphrase = `cap gnal cirs foo kouw keap noos paix teem cler gnex douh cap gnal cirs foo kouw keap noos paix teem cler gnex douh cap gnal cirs foo kouw keap noos paix teem cler gnex douh cap gnal cirs foo`;
+
+    // More on how to set up stories at: https://storybook.js.org/docs/writing-stories
+    const { Story } = defineMeta({
+        title: "Component/Passphrase Card",
+        component: Button,
+        tags: ["autodocs"],
+        args: {
+            passphrase: demoPassphrase,
+        },
+    });
+</script>
+
+<Story name="Default" />

--- a/src/lib/components/Passphrase-Card.svelte
+++ b/src/lib/components/Passphrase-Card.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+    const { passphrase, getNewPassphrasFn } = $props();
+
+    const copyToClipboard: any = () => {
+        navigator.clipboard.writeText(passphrase);
+    };
+</script>
+
+<section class="passphraseCard">
+    <div class="heading">
+        <div class="title">Secret Passphrase</div>
+        <button class="button" onclick={getNewPassphrasFn}>New</button>
+    </div>
+    <p class="code">{passphrase}</p>
+    <button class="button" onclick={copyToClipboard}>Copy</button>
+</section>
+
+<style>
+    .passphraseCard {
+        max-width: 430px;
+        background-color: #09531a;
+        padding-block: var(--space-s);
+        padding-inline: var(--space-l);
+        border-radius: var(--radii-soft);
+    }
+
+    .heading {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-block-end: var(--space-xs);
+    }
+
+    .title {
+        text-transform: uppercase;
+        font-size: var(--step--2);
+        color: #c9b0e2;
+        font-weight: 600;
+    }
+
+    .code {
+        font-family: monospace;
+        background-image: linear-gradient(135deg, #b0d9b9, #ffffff, #80f69b);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        margin-block-end: var(--space-xs);
+    }
+
+    .button {
+        font-size: var(--step--1);
+        color: #c1dec4;
+        border: 1px solid #437a50;
+        border-radius: var(--radii-pill);
+        padding-block: var(--space-3xs);
+        padding-inline: var(--space-xs);
+        line-height: var(--lh-ui);
+        cursor: pointer;
+
+        &:hover,
+        &:focus {
+            transform: translateY(-1px);
+        }
+
+        &:active {
+            transform: translateY(0px);
+        }
+    }
+</style>

--- a/src/lib/styles/foundation.css
+++ b/src/lib/styles/foundation.css
@@ -5,4 +5,5 @@
 @import "./module/defaults.css" layer(global);
 @import "./module/font-size.css" layer(token);
 @import "./module/reset.css" layer(reset);
+@import "./module/line-height.css" layer(token);
 @import "./module/space.css" layer(token);

--- a/src/lib/styles/module/border-radius.css
+++ b/src/lib/styles/module/border-radius.css
@@ -1,5 +1,6 @@
 :root {
     --radii-sharp: 0px;
     --radii-pill: 5000px;
+    --radii-soft: 14px;
     --radii-circle: 50%;
 }

--- a/src/lib/styles/module/line-height.css
+++ b/src/lib/styles/module/line-height.css
@@ -1,0 +1,6 @@
+:root {
+    --lh-normal: 1.4;
+    --lh-tight: 1.2;
+    --lh-airy: 1.6;
+    --lh-ui: 1;
+}

--- a/src/lib/styles/module/typography.css
+++ b/src/lib/styles/module/typography.css
@@ -59,17 +59,17 @@
 }
 
 .u\:lh-tight {
-    line-height: 1.2;
+    line-height: var(--lh-tight);
 }
 
 .u\:lh-normal {
-    line-height: 1.4;
+    line-height: var(--lh-normal);
 }
 
 .u\:lh-airy {
-    line-height: 1.6;
+    line-height: var(--lh-airy);
 }
 
 .u\:lh-ui {
-    line-height: 1;
+    line-height: var(--lh-ui);
 }


### PR DESCRIPTION
- added some tokens for line-height so that we can use them in a class or as a utility class
- added a passphrase card component that accepts a passphrase to be used as well as a button to request a new passphrase. 

in a future pass, I'd like to add:
- better documentation in storybook
- once color tokens are in, add dark mode support
- icons from a future icon component
- a better interaction when a passphrase is copied
  - the text should momentarily change to "copied" along with the style of the button possibly
  - if a new passphrase is requested, the copy button should go back to its default state